### PR TITLE
Use NuGet package references

### DIFF
--- a/LSIIC/Assembly-CSharp.LSIIC.mm/Assembly-CSharp.LSIIC.mm.csproj
+++ b/LSIIC/Assembly-CSharp.LSIIC.mm/Assembly-CSharp.LSIIC.mm.csproj
@@ -51,6 +51,12 @@
 		</Reference>
 	</ItemGroup>
 
+	<ItemGroup>
+	  <PackageReference Include="BepInEx.Core" Version="5.4.16" />
+	  <PackageReference Include="H3VR.GameLibs" Version="0.100.2-r.1" />
+	  <PackageReference Include="UnityEngine" Version="5.6.1" />
+	</ItemGroup>
+
 	<!-- Import our commonized copy-to-game logic -->
 	<Import Project="$(SolutionDir)LSIIC.CopyToGame.targets" />
 

--- a/LSIIC/Assembly-CSharp.LSIIC.mm/Assembly-CSharp.LSIIC.mm.csproj
+++ b/LSIIC/Assembly-CSharp.LSIIC.mm/Assembly-CSharp.LSIIC.mm.csproj
@@ -25,39 +25,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="0Harmony">
-			<HintPath>$(SolutionDir)..\lib\0Harmony.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="Assembly-CSharp">
-			<HintPath>$(SolutionDir)..\lib\Assembly-CSharp.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="Assembly-CSharp-firstpass">
-		  <HintPath>..\..\lib\Assembly-CSharp-firstpass.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="BepInEx">
-			<HintPath>$(SolutionDir)..\lib\BepInEx.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="UnityEngine">
-			<HintPath>$(SolutionDir)..\lib\UnityEngine.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="UnityEngine.UI">
-		  <HintPath>..\..\lib\UnityEngine.UI.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-	</ItemGroup>
-
-	<ItemGroup>
 	  <PackageReference Include="BepInEx.Core" Version="5.4.16" />
 	  <PackageReference Include="H3VR.GameLibs" Version="0.100.2-r.1" />
 	  <PackageReference Include="UnityEngine" Version="5.6.1" />
 	</ItemGroup>
-
-	<!-- Import our commonized copy-to-game logic -->
-	<Import Project="$(SolutionDir)LSIIC.CopyToGame.targets" />
 
 </Project>

--- a/LSIIC/LSIIC.Core/LSIIC.Core.csproj
+++ b/LSIIC/LSIIC.Core/LSIIC.Core.csproj
@@ -12,45 +12,11 @@
 		<OutputPath>$(SolutionDir)..\bin\BepInEx\plugins\LSIIC</OutputPath>
 		<DebugType>none</DebugType>
 	</PropertyGroup>
-
-	<ItemGroup>
-		<Reference Include="0Harmony">
-			<HintPath>$(SolutionDir)..\lib\0Harmony.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="ES2">
-			<HintPath>$(SolutionDir)..\lib\ES2.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="Assembly-CSharp">
-			<HintPath>$(SolutionDir)..\lib\Assembly-CSharp.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="Assembly-CSharp">
-			<HintPath>$(SolutionDir)..\lib\Assembly-CSharp-firstpass.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="BepInEx">
-			<HintPath>$(SolutionDir)..\lib\BepInEx.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="UnityEngine">
-			<HintPath>$(SolutionDir)..\lib\UnityEngine.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="UnityEngine.UI">
-			<HintPath>$(SolutionDir)..\lib\UnityEngine.UI.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-	</ItemGroup>
-
+	
 	<ItemGroup>
 	  <PackageReference Include="BepInEx.Core" Version="5.4.16" />
 	  <PackageReference Include="H3VR.GameLibs" Version="0.100.2-r.1" />
 	  <PackageReference Include="UnityEngine" Version="5.6.1" />
 	</ItemGroup>
-
-	<!-- Import our commonized copy-to-game logic -->
-	<Import Project="$(SolutionDir)LSIIC.CopyToGame.targets" />
 
 </Project>

--- a/LSIIC/LSIIC.Core/LSIIC.Core.csproj
+++ b/LSIIC/LSIIC.Core/LSIIC.Core.csproj
@@ -44,6 +44,12 @@
 		</Reference>
 	</ItemGroup>
 
+	<ItemGroup>
+	  <PackageReference Include="BepInEx.Core" Version="5.4.16" />
+	  <PackageReference Include="H3VR.GameLibs" Version="0.100.2-r.1" />
+	  <PackageReference Include="UnityEngine" Version="5.6.1" />
+	</ItemGroup>
+
 	<!-- Import our commonized copy-to-game logic -->
 	<Import Project="$(SolutionDir)LSIIC.CopyToGame.targets" />
 

--- a/LSIIC/LSIIC.SmartPalming/LSIIC.SmartPalming.csproj
+++ b/LSIIC/LSIIC.SmartPalming/LSIIC.SmartPalming.csproj
@@ -14,31 +14,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<Reference Include="0Harmony">
-			<HintPath>$(SolutionDir)..\lib\0Harmony.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="Assembly-CSharp">
-			<HintPath>$(SolutionDir)..\lib\Assembly-CSharp.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="BepInEx">
-			<HintPath>$(SolutionDir)..\lib\BepInEx.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="UnityEngine">
-			<HintPath>$(SolutionDir)..\lib\UnityEngine.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-	</ItemGroup>
-
-	<ItemGroup>
 	  <PackageReference Include="BepInEx.Core" Version="5.4.16" />
 	  <PackageReference Include="H3VR.GameLibs" Version="0.100.2-r.1" />
 	  <PackageReference Include="UnityEngine" Version="5.6.1" />
 	</ItemGroup>
-
-	<!-- Import our commonized copy-to-game logic -->
-	<Import Project="$(SolutionDir)LSIIC.CopyToGame.targets" />
 
 </Project>

--- a/LSIIC/LSIIC.SmartPalming/LSIIC.SmartPalming.csproj
+++ b/LSIIC/LSIIC.SmartPalming/LSIIC.SmartPalming.csproj
@@ -32,6 +32,12 @@
 		</Reference>
 	</ItemGroup>
 
+	<ItemGroup>
+	  <PackageReference Include="BepInEx.Core" Version="5.4.16" />
+	  <PackageReference Include="H3VR.GameLibs" Version="0.100.2-r.1" />
+	  <PackageReference Include="UnityEngine" Version="5.6.1" />
+	</ItemGroup>
+
 	<!-- Import our commonized copy-to-game logic -->
 	<Import Project="$(SolutionDir)LSIIC.CopyToGame.targets" />
 

--- a/LSIIC/LSIIC.VirtualObjectsInjector/LSIIC.VirtualObjectsInjector.csproj
+++ b/LSIIC/LSIIC.VirtualObjectsInjector/LSIIC.VirtualObjectsInjector.csproj
@@ -14,35 +14,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<Reference Include="0Harmony">
-			<HintPath>$(SolutionDir)..\lib\0Harmony.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="Assembly-CSharp">
-			<HintPath>$(SolutionDir)..\lib\Assembly-CSharp.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="Assembly-CSharp">
-			<HintPath>$(SolutionDir)..\lib\Assembly-CSharp-firstpass.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="BepInEx">
-			<HintPath>$(SolutionDir)..\lib\BepInEx.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-		<Reference Include="UnityEngine">
-			<HintPath>$(SolutionDir)..\lib\UnityEngine.dll</HintPath>
-			<Private>false</Private>
-		</Reference>
-	</ItemGroup>
-
-	<ItemGroup>
 	  <PackageReference Include="BepInEx.Core" Version="5.4.16" />
 	  <PackageReference Include="H3VR.GameLibs" Version="0.100.2-r.1" />
 	  <PackageReference Include="UnityEngine" Version="5.6.1" />
 	</ItemGroup>
-
-	<!-- Import our commonized copy-to-game logic -->
-	<Import Project="$(SolutionDir)LSIIC.CopyToGame.targets" />
 
 </Project>

--- a/LSIIC/LSIIC.VirtualObjectsInjector/LSIIC.VirtualObjectsInjector.csproj
+++ b/LSIIC/LSIIC.VirtualObjectsInjector/LSIIC.VirtualObjectsInjector.csproj
@@ -36,6 +36,12 @@
 		</Reference>
 	</ItemGroup>
 
+	<ItemGroup>
+	  <PackageReference Include="BepInEx.Core" Version="5.4.16" />
+	  <PackageReference Include="H3VR.GameLibs" Version="0.100.2-r.1" />
+	  <PackageReference Include="UnityEngine" Version="5.6.1" />
+	</ItemGroup>
+
 	<!-- Import our commonized copy-to-game logic -->
 	<Import Project="$(SolutionDir)LSIIC.CopyToGame.targets" />
 

--- a/LSIIC/nuget.config
+++ b/LSIIC/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <add key="BepInEx" value="https://nuget.bepinex.dev/v3/index.json" />
+    </packageSources>
+</configuration>


### PR DESCRIPTION
This PR uses NuGet package references for H3, and removes old ones. Also deletes the move to game target references, as those do not work